### PR TITLE
Update dead link on gh-pages to Chrome Extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <div class="description">
       <h2>Trakt.tv + Netflix = ❤️</h2>
       <h3>Sync your Netflix history with Trakt.tv</h3>
-      <a target="_blank" href="https://chrome.google.com/webstore/detail/bmoemkaigjgcgjjnpmdgkifndiidkeji?utm_source=landing&utm_medium=badge&%20utm_campaign=page">
+      <a target="_blank" href="https://chrome.google.com/webstore/detail/traktflix/ehlckfimahifadnbecobagimllmbdmde">
         <img src="ChromeWebStore_BadgeWBorder_v2_206x58.png" alt="Download it in chrome web store" class="chrome-store-badge" />
       </a>
     </div>


### PR DESCRIPTION
The link to the Chrome Extension that is currently on https://tegon.github.io/traktflix/ is dead.
Changed the link to the fixed one.