### PR TITLE
ignore < 80% watched

### DIFF
--- a/src/class/NetflixApiUtils.js
+++ b/src/class/NetflixApiUtils.js
@@ -74,7 +74,7 @@ const netflixApiUtils = {
         });
         const _activities = JSON.parse(response).viewedItems;
         if (_activities.length) {
-          _activities.forEach(a => {if((a.bookmark/a.duration)>0.8) {activities.push(a)}})
+          activities.push(...(_activities.filter(a => (a.bookmark/a.duration)>0.8)));
         } else {
           isLastPage = true;
         }

--- a/src/class/NetflixApiUtils.js
+++ b/src/class/NetflixApiUtils.js
@@ -74,7 +74,7 @@ const netflixApiUtils = {
         });
         const _activities = JSON.parse(response).viewedItems;
         if (_activities.length) {
-          activities.push(..._activities);
+          _activities.forEach(a => {if((a.bookmark/a.duration)>0.8) {activities.push(a)}})
         } else {
           isLastPage = true;
         }


### PR DESCRIPTION
This will ignore episodes and movies that haven't been watched for more than 80% of duration. This should cover longer end credits (ex: 18min on 1.5h movie, 6min on 30min episode, etc). 

Fixes #138 