### PR TITLE
fix for multiple history entries in trakt

### DIFF
--- a/src/class/history-sync/TraktWebAPIUtils.js
+++ b/src/class/history-sync/TraktWebAPIUtils.js
@@ -110,15 +110,17 @@ export default class TraktWebAPIUtils {
         url: TraktWebAPIUtils.activityUrl(options.result.activity),
         success: function (response) {
           let alreadyOnTrakt = false;
-          const history = JSON.parse(response)[0];
           let date;
 
-          if (history && history.watched_at) {
-            date = moment(history.watched_at);
-            alreadyOnTrakt = date.diff(options.netflix.date, `days`) === 0;
-          }
-          options.trakt = Object.assign(options.result.activity, {date});
-          options.alreadyOnTrakt = alreadyOnTrakt;
+          const historyEntries = JSON.parse(response);
+          historyEntries.forEach(history => {
+            if (history && history.watched_at) {
+              date = moment(history.watched_at);
+              alreadyOnTrakt = date.diff(options.netflix.date, `days`) === 0;
+            }
+            options.trakt = Object.assign(options.result.activity, {date});
+            options.alreadyOnTrakt = alreadyOnTrakt;
+          })
           resolve();
         },
         error: reject

--- a/src/class/history-sync/TraktWebAPIUtils.js
+++ b/src/class/history-sync/TraktWebAPIUtils.js
@@ -113,14 +113,17 @@ export default class TraktWebAPIUtils {
           let date;
 
           const historyEntries = JSON.parse(response);
-          historyEntries.forEach(history => {
+          for (let history of historyEntries) {
             if (history && history.watched_at) {
               date = moment(history.watched_at);
-              alreadyOnTrakt = date.diff(options.netflix.date, `days`) === 0;
+              if (date.diff(options.netflix.date, `days`) === 0) {
+                alreadyOnTrakt = true;
+                break;
+              }
             }
-            options.trakt = Object.assign(options.result.activity, {date});
-            options.alreadyOnTrakt = alreadyOnTrakt;
-          })
+          }
+          options.trakt = Object.assign(options.result.activity, {date});
+          options.alreadyOnTrakt = alreadyOnTrakt;
           resolve();
         },
         error: reject

--- a/src/class/history-sync/TraktWebAPIUtils.js
+++ b/src/class/history-sync/TraktWebAPIUtils.js
@@ -112,7 +112,7 @@ export default class TraktWebAPIUtils {
           let alreadyOnTrakt = false;
           let date;
 
-          const historyEntries = JSON.parse(response);
+          const historyEntries = JSON.parse(response).reverse();
           for (let history of historyEntries) {
             if (history && history.watched_at) {
               date = moment(history.watched_at);


### PR DESCRIPTION
Instead of just using the most recent check-in from Trakt, this will loop through them and mark as synced if any of the history entries match Netflix history. 

It would probably be better to show all Trakt check-ins (and not only the matching one), but this at least fixes #134 