### PR TITLE
Fix for when only one movie search result and not exact name/year match

### DIFF
--- a/src/class/Search.js
+++ b/src/class/Search.js
@@ -20,7 +20,7 @@ export default class Search {
       url: this.getUrl(),
       success: function (response) {
         let data = JSON.parse(response);
-        if (_this.item && _this.item.type === `movie`) {
+        if (data.length > 1 && _this.item && _this.item.type === `movie`) {
           // Get exact match if there are multiple movies with the same name by checking the year.
           data = data.filter(item => item.movie.title === _this.item.title && item.movie.year === _this.item.year)[0];
         } else {


### PR DESCRIPTION
This is a small fix for a bug that was caused when Trakt movie search result only return one item and that item wasn't an exact match with name and year. 

There's an if-case in the code to filter out the correct movie if there are multiple movies with similar name, by checking for exact match in name and year:
```js
if (_this.item && _this.item.type === `movie`) {
   // Get exact match if there are multiple movies with the same name by checking the year.
   data = data.filter(item => item.movie.title === _this.item.title && item.movie.year === _this.item.year)[0];
}
``` 
But this check is also run if Trakt just return one result, which seems unnecessary, since we don't care about exact name and year match if we just get one result. It also caused the Trakt data to be undefined if the one result isn't an exact match. 

So I added to skip the check if Trakt only returns one result.

Example movies: 
- Netflix: iBOY 2017 | Trakt: iBoy 2017
- Netflix: Unicorn Store 2019 | Trakt: Unicorn Store 2017