### PR TITLE
Update README to show that traktflix has been discontinued

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<h1 align="center"><strong>traktflix</strong> was discontinued in favor of <a href="https://github.com/trakt-tools/universal-trakt-scrobbler">universal-trakt-scrobbler</a></h1>
+
+
+
 <h1 align="center">
   <br>
   <a href="https://tegon.github.io/traktflix/">


### PR DESCRIPTION
Include a note indicating that the project has been discontinued in favor of [universal-trakt-scrobbler](https://github.com/trakt-tools/universal-trakt-scrobbler) as indicated in the  ["Credits" session on their README.md](https://github.com/trakt-tools/universal-trakt-scrobbler#credits).